### PR TITLE
Add validation for JIRA Server field

### DIFF
--- a/ext/config.js
+++ b/ext/config.js
@@ -1,6 +1,12 @@
 var selectedProjects = [];
 
 function jiraServerChanged() {
+  var jiraServerField = $("#jira_server");
+
+  if (!jiraServerField[0].checkValidity()) {
+    jiraServerField[0].reportValidity();
+  }
+
   $("#loadProjectKeys").show();
   save_options();
 }

--- a/ext/jirafy-config.html
+++ b/ext/jirafy-config.html
@@ -62,7 +62,7 @@
               </div>
               <div class="setting container text">
                 <label class="setting label text" for="jira_server">JIRA Server:</label>
-                <input type="text" name="jira_server" id="jira_server" placeholder="https://jira.example.com/"/>
+                <input type="text" name="jira_server" id="jira_server" placeholder="https://jira.example.com/" title="Enter the JIRA Server including protocol." pattern="https?:\/\/.+"/>
                 <a id="loadProjectKeys">Detect Projects</a>
               </div>
               <div class="setting bundle description">


### PR DESCRIPTION
This pull request adds a `pattern` and `title` attribute to the JIRA Server field so we can validate it when changing it's value. You can verify the RegEx [here](https://regex101.com/r/1p2Xpl/1).

_I also thought about using `<input type="url">` but this requires more styling so I just added the `pattern` attribute for validation_

## Wrong URL

<img width="521" alt="screen shot 2017-10-06 at 14 49 10" src="https://user-images.githubusercontent.com/1086961/31278553-a1d96b58-aaa5-11e7-85e1-0954fe3739f4.png">

## Correct URL

<img width="537" alt="screen shot 2017-10-06 at 14 49 18" src="https://user-images.githubusercontent.com/1086961/31278562-a9f04f50-aaa5-11e7-8d54-126dcaa80cc1.png">

This fixes #17 :hammer:
