### PR TITLE
Adjust "Ignore Elements" <input>

### DIFF
--- a/ext/jirafy-config.html
+++ b/ext/jirafy-config.html
@@ -39,11 +39,11 @@
               <div class="setting bundle text">
                 <div class="setting container text">
                   <label class="setting label text" for="ignore_elements">Ignore Elements</label>
-                  <input type="text" name="ignore_elements" id="ignore_elements" size="100" placeholder="a,textarea,code"/>
+                  <input type="text" name="ignore_elements" id="ignore_elements" size="100" placeholder="pre,code"/>
                 </div>
               </div>
               <div class="setting bundle description">
-                Comma-separated elements that you would like to ignore. If you know you won't need to Jirafy any links in a particular element this could speed up the process. Example: "a,textarea,code,div"
+                Comma-separated elements that you would like to ignore. If you know you won't need to Jirafy any links in a particular element this could speed up the process."
               </div>
             </td>
           </tr>


### PR DESCRIPTION
We should use the same [default value](https://github.com/square/jirafy/blob/master/ext/config.js#L38) as that one we are using for restoring options.

I have also removed the extra elements from the description text because we are already using default value/placeholder here.